### PR TITLE
[MultipleFixes] Fixed `init-drupal` for composer's memory-limit-errors and `init-lando` for FileNotFoundError

### DIFF
--- a/axltempl/drupal.py
+++ b/axltempl/drupal.py
@@ -88,7 +88,9 @@ def main(
 
     if not no_install:
         if shutil.which("composer") is not None:
-            os.system("composer install -o")
+            status = os.system("composer install -o")
+            if status != 0:
+                util.writeError('Composer is unable to resolves and install the dependencies. Skipping install...')
         else:
             util.writeWarning("Cannot find composer. Skipping install...")
 

--- a/axltempl/drupal.py
+++ b/axltempl/drupal.py
@@ -100,7 +100,7 @@ def main(
         name = name.split("/")
         name = name[1] if len(name) == 2 else name[0]
         util.writeInfo("Adding Lando support...")
-        lando.generateLandoFile(name, docroot, cache)
+        lando.generateLandoFiles(name, docroot, cache)
 
     os.chdir("..")
     return 0

--- a/axltempl/drupal.py
+++ b/axltempl/drupal.py
@@ -100,7 +100,15 @@ def main(
         name = name.split("/")
         name = name[1] if len(name) == 2 else name[0]
         util.writeInfo("Adding Lando support...")
-        lando.generateLandoFiles(name, docroot, cache)
+        lando.generateLandoFile(name, docroot, cache)
+
+        dir_default = f'{docroot}/sites/default'
+        if os.path.exists(dir_default):
+            # Generate lando development override configuration.
+            lando.generateLandoDevelopmentSettingsFiles(docroot, cache)
+        else:
+            util.writeWarning(
+                f'"{dir_default}" is missing. Unable to generate lando development override configuration.')
 
     os.chdir("..")
     return 0

--- a/axltempl/drupal.py
+++ b/axltempl/drupal.py
@@ -102,14 +102,6 @@ def main(
         util.writeInfo("Adding Lando support...")
         lando.generateLandoFile(name, docroot, cache)
 
-        dir_default = f'{docroot}/sites/default'
-        if os.path.exists(dir_default):
-            # Generate lando development override configuration.
-            lando.generateLandoDevelopmentSettingsFiles(docroot, cache)
-        else:
-            util.writeWarning(
-                f'"{dir_default}" is missing. Unable to generate lando development override configuration.')
-
     os.chdir("..")
     return 0
 

--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -27,10 +27,10 @@ def main():
     elif "drupal/memcache" in composer["require"].keys():
         cache = "memcached"
 
-    generateLandoFile(name, docroot, cache)
+    generateLandoFiles(name, docroot, cache)
 
 
-def generateLandoFile(name, docroot, cache):
+def generateLandoFiles(name, docroot, cache):
     services = ""
     tooling = ""
     if cache == "redis":
@@ -57,13 +57,6 @@ def generateLandoFile(name, docroot, cache):
     util.copyPackageFile("files/lando/php.ini", ".lando/php.ini")
 
     # Generate lando development override configuration.
-    generateLandoDevelopmentSettingsFiles(docroot, cache)
-
-    return 0
-
-
-def generateLandoDevelopmentSettingsFiles(docroot, cache):
-
     dir_default = f"{docroot}/sites/default"
     if not os.path.exists(dir_default):
         util.writeError(

--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -27,10 +27,11 @@ def main():
     elif "drupal/memcache" in composer["require"].keys():
         cache = "memcached"
 
-    generateLandoFiles(name, docroot, cache)
+    generateLandoFile(name, docroot, cache)
+    generateLandoDevelopmentSettingsFiles(docroot, cache)
 
 
-def generateLandoFiles(name, docroot, cache):
+def generateLandoFile(name, docroot, cache):
     services = ""
     tooling = ""
     if cache == "redis":
@@ -56,6 +57,10 @@ def generateLandoFiles(name, docroot, cache):
         os.mkdir(".lando")
     util.copyPackageFile("files/lando/php.ini", ".lando/php.ini")
 
+    return 0
+
+
+def generateLandoDevelopmentSettingsFiles(docroot, cache):
     landoSettings = util.readPackageFile("files/lando/settings.lando.php")
     if cache == "redis":
         landoSettings += util.readPackageFile("files/lando/lando.redis.php")

--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -28,7 +28,6 @@ def main():
         cache = "memcached"
 
     generateLandoFile(name, docroot, cache)
-    generateLandoDevelopmentSettingsFiles(docroot, cache)
 
 
 def generateLandoFile(name, docroot, cache):
@@ -57,10 +56,20 @@ def generateLandoFile(name, docroot, cache):
         os.mkdir(".lando")
     util.copyPackageFile("files/lando/php.ini", ".lando/php.ini")
 
+    # Generate lando development override configuration.
+    generateLandoDevelopmentSettingsFiles(docroot, cache)
+
     return 0
 
 
 def generateLandoDevelopmentSettingsFiles(docroot, cache):
+
+    dir_default = f"{docroot}/sites/default"
+    if not os.path.exists(dir_default):
+        util.writeError(
+            f"The \"{dir_default}\" directory is missing. Unable to generate lando override configuration files.")
+        return 0
+
     landoSettings = util.readPackageFile("files/lando/settings.lando.php")
     if cache == "redis":
         landoSettings += util.readPackageFile("files/lando/lando.redis.php")


### PR DESCRIPTION
The PR changes fix for,

- **`composer install -o`  error** 
```bash
% init-drupal --directory=d8-dev --core=core drupal
Initialized empty Git repository in /private/var/www/contrib/d8-dev/.git/
[master (root-commit) 8dc7a87] Initial commit
Deprecation warning: Your package name drupal is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$". Make sure you fix this as Composer 2.0 will error.
   ........
    Finished: success: 37, skipped: 0, failure: 0, total: 37
Loading composer repositories with package information
Updating dependencies (including require-dev)
PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52

Fatal error: Allowed memory size of 1610612736 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52

Check https://getcomposer.org/doc/articles/troubleshooting.md#memory-limit-errors for more info on how to handle out of memory errors.
% 
```

- **Error generating lando development override configuration file**

```bash
% init-drupal --directory=d8-dev --lando --no-install drupal
Initialized empty Git repository in /private/var/www/contrib/d8-dev/d8-dev/.git/
[master (root-commit) 248dd89] Initial commit
Adding Lando support...
Traceback (most recent call last):
  File "/usr/local/bin/init-drupal", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/axltempl/drupal.py", line 46, in main
    lando.generateLandoFiles(name, args.docroot, args.cache)
  File "/usr/local/lib/python3.7/site-packages/axltempl/lando.py", line 64, in generateLandoFiles
    util.writeFile(docroot + "/sites/default/settings.lando.php", landoSettings)
  File "/usr/local/lib/python3.7/site-packages/axltempl/util.py", line 17, in writeFile
    with open(file, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'web/sites/default/settings.lando.php'
%
```

- **`composer init-lando`** error
```bash
% init-lando
Traceback (most recent call last):
  File "/usr/local/bin/init-lando", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/axltempl/lando.py", line 30, in main
    generateLandoFiles(name, docroot, cache)
  File "/usr/local/lib/python3.7/site-packages/axltempl/lando.py", line 64, in generateLandoFiles
    util.writeFile(docroot + "/sites/default/settings.lando.php", landoSettings)
  File "/usr/local/lib/python3.7/site-packages/axltempl/util.py", line 17, in writeFile
    with open(file, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'web/sites/default/settings.lando.php'
%
```