### PR TITLE
Added check to exit if composer fails to install vendors.

### DIFF
--- a/axltempl/drupal.py
+++ b/axltempl/drupal.py
@@ -88,9 +88,8 @@ def main(
 
     if not no_install:
         if shutil.which("composer") is not None:
-            status = os.system("composer install -o")
-            if status != 0:
-                util.writeError('Composer is unable to resolves and install the dependencies. Skipping install...')
+            if os.system("composer install -o") != 0:
+                util.writeError("Error when running 'composer install'. Skipping install...")
         else:
             util.writeWarning("Cannot find composer. Skipping install...")
 

--- a/axltempl/drupal.py
+++ b/axltempl/drupal.py
@@ -88,7 +88,9 @@ def main(
 
     if not no_install:
         if shutil.which("composer") is not None:
-            os.system("composer install -o")
+            status = os.system("composer install -o")
+            if status != 0:
+                util.writeError('Composer is unable to resolves and install the dependencies. Skipping install...')
         else:
             util.writeWarning("Cannot find composer. Skipping install...")
 


### PR DESCRIPTION
 **Added check on `composer install -o` exit error** 
```bash
% init-drupal --directory=d8-dev --core=core drupal
Initialized empty Git repository in /private/var/www/contrib/d8-dev/.git/
[master (root-commit) 8dc7a87] Initial commit
Deprecation warning: Your package name drupal is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$". Make sure you fix this as Composer 2.0 will error.
   ........
    Finished: success: 37, skipped: 0, failure: 0, total: 37
Loading composer repositories with package information
Updating dependencies (including require-dev)
PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52

Fatal error: Allowed memory size of 1610612736 bytes exhausted (tried to allocate 4096 bytes) in phar:///usr/local/bin/composer/src/Composer/DependencyResolver/RuleWatchGraph.php on line 52

Check https://getcomposer.org/doc/articles/troubleshooting.md#memory-limit-errors for more info on how to handle out of memory errors.
% 
```

**Note**
Use environment variable as,
`COMPOSER_MEMORY_LIMIT=-1 init-drupal --directory=d8 --core=core my/site`
