### PR TITLE
Fixed "init-lando" FileNotFoundError

### DIFF
--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -71,6 +71,13 @@ def generate_lando_files(name, docroot, cache):
         os.mkdir(".lando")
     util.copy_package_file("files/lando/php.ini", ".lando/php.ini")
 
+    # Generate lando development override configuration.
+    dir_default = f"{docroot}/sites/default"
+    if not os.path.exists(dir_default):
+        util.writeError(
+            f"The \"{dir_default}\" directory is missing. Unable to generate lando override configuration files.")
+        return 0
+
     lando_settings = util.read_package_file("files/lando/settings.lando.php")
     if cache == "redis":
         lando_settings += util.read_package_file("files/lando/lando.redis.php")

--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -74,8 +74,10 @@ def generate_lando_files(name, docroot, cache):
     # Generate lando development override configuration.
     dir_default = f"{docroot}/sites/default"
     if not os.path.exists(dir_default):
-        util.writeError(
-            f"The \"{dir_default}\" directory is missing. Unable to generate lando override configuration files.")
+        util.write_error(
+            f'The "{dir_default}" directory is missing.'
+            + "Unable to generate lando override configuration files."
+        )
         return 0
 
     lando_settings = util.read_package_file("files/lando/settings.lando.php")

--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -75,10 +75,15 @@ def generate_lando_files(name, docroot, cache):
     dir_default = f"{docroot}/sites/default"
     if not os.path.exists(dir_default):
         util.write_error(
-            f'The "{dir_default}" directory is missing.'
+            f'The "{dir_default}" directory is missing. '
             + "Unable to generate lando override configuration files."
         )
-        return 0
+        util.write_info(
+            "This is probably due to composer installation failure "
+            + "(or you specified --no-install). "
+            + "Run init-lando after running composer install."
+        )
+        return 2
 
     lando_settings = util.read_package_file("files/lando/settings.lando.php")
     if cache == "redis":


### PR DESCRIPTION
**`init-lando` throws FileNotFoundError error** 

```bash
% init-lando
Traceback (most recent call last):
  File "/usr/local/bin/init-lando", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/axltempl/lando.py", line 30, in main
    generateLandoFiles(name, docroot, cache)
  File "/usr/local/lib/python3.7/site-packages/axltempl/lando.py", line 64, in generateLandoFiles
    util.writeFile(docroot + "/sites/default/settings.lando.php", landoSettings)
  File "/usr/local/lib/python3.7/site-packages/axltempl/util.py", line 17, in writeFile
    with open(file, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'web/sites/default/settings.lando.php'
%
```