### PR TITLE
Adding environment variable files in lando.

### DIFF
--- a/axltempl/files/drupal/.env.example
+++ b/axltempl/files/drupal/.env.example
@@ -31,5 +31,5 @@
 # drush php-eval 'echo \Drupal\Component\Utility\Crypt::randomBytesBase64(55);'
 # HASH_SALT=
 
-# Another common use case is to set Drush's --uri via environment.
-# DRUSH_OPTIONS_URI=http://example.com
+# Set DRUSH_OPTIONS_URI
+DRUSH_OPTIONS_URI=http://{name}.lndo.site/

--- a/axltempl/files/drupal/drush.yml
+++ b/axltempl/files/drupal/drush.yml
@@ -4,5 +4,3 @@
 # Docs at https://github.com/drush-ops/drush/blob/master/examples/example.drush.yml
 #
 # Edit or remove this file as needed.
-options:
-  uri: 'http://{name}.lndo.site/'

--- a/axltempl/files/lando/lando.yml
+++ b/axltempl/files/lando/lando.yml
@@ -1,6 +1,7 @@
 name: {name}
 recipe: drupal8
-
+env_file:
+  - .lando/defaults.env
 services:
   appserver:
     type: php:7.4

--- a/axltempl/lando.py
+++ b/axltempl/lando.py
@@ -102,4 +102,8 @@ def generate_lando_files(name, docroot, cache):
         "Change the database image from mariadb to your desired image in .lando.yml."
     )
 
+    env_file = util.read_package_file("files/drupal/.env.example")
+    env_file = env_file.replace("{name}", name)
+    util.write_file(".lando/defaults.env", env_file)
+
     return 0


### PR DESCRIPTION
Currently DRUSH_OPTIONS_URI  is set in drush.yml file.
This is causing issues with hosts like platform.sh where they are reading this file as well.
For now we can use environment variables in .lando directory so it remains active for local only.
Another use case is when we configure blackfire etc. we need to add environment variables for those as well.
Having seperate environment variable file specific to local lando can be useful for those cases.